### PR TITLE
update runner ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: crystal-ameba/github-action@v0.2.12
@@ -15,7 +15,7 @@ jobs:
 
   spec:
     name: Spec
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: crystal-lang/install-crystal@v1


### PR DESCRIPTION
### WHY are these changes introduced?
 he Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.